### PR TITLE
Fix tight inifinite loop in script to check vm.max_map_count

### DIFF
--- a/install/istio/install.yaml
+++ b/install/istio/install.yaml
@@ -50,7 +50,7 @@ objects:
           - "bash"
           args:
           - "-c"
-          - "while : ; do current=$(sysctl -n vm.max_map_count) ; if [ \"${current}\" -lt 262144 ] ; then echo \"$(date): Current vm.max_map_count setting is ${current}, updating to 262144 for Elasticsearch\" ; sysctl vm.max_map_count=262144 ; sleep 60 ; fi ; done"
+          - "while : ; do current=$(sysctl -n vm.max_map_count) ; if [ \"${current}\" -lt 262144 ] ; then echo \"$(date): Current vm.max_map_count setting is ${current}, updating to 262144 for Elasticsearch\" ; sysctl vm.max_map_count=262144 ; fi; sleep 60 ; done"
 
 - apiVersion: apps/v1
   kind: Deployment


### PR DESCRIPTION
I am not sure why the ES watchdog script to fix the sysctl value is needed (assuming _some_ other thing might be changing the sysctl independently), but it was bringing my 2-core VM to its knees, with one core busily checking for the vm.max_map_count sysctl.

This was due to a misplaced sleep command, and this should fix it, but note that I have not set up an environment to build and test it as of yet.

Automatically generated files still need to get this change applied though (ie. bindata.go in a couple places).